### PR TITLE
Improved browser support: IE11

### DIFF
--- a/src/Bars.js
+++ b/src/Bars.js
@@ -161,12 +161,7 @@ const Bars = React.createClass({
 
         groupStyle = helpers.value(groupStyle, {seriesIndex, pointIndex, point, series, props});
 
-        const transform = 'translate3d(' + x + 'px,' + y + 'px,0px)';
-        const style = _.defaults({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform
-        }, groupStyle);
+        const transform = 'translate(' + x + ',' + y + ')';
 
         const d = (scaleX.swap || scaleY.swap) ?
             ('M0,' + (-height / 2) + ' h' + (width) + ' v' + height + ' h' + (-width) + ' Z') :
@@ -180,7 +175,8 @@ const Bars = React.createClass({
         return <g
             key={pointIndex}
             className={className && (className + '-bar ' + className + '-bar-'  + pointIndex)}
-            style={style}>
+            style={groupStyle}
+            transform={transform}>
             <path
                 style={barStyle}
                 fill={point.color || series.color || this.color(seriesIndex)}

--- a/src/Dots.js
+++ b/src/Dots.js
@@ -229,12 +229,7 @@ const Dots = React.createClass({
 
         groupStyle = helpers.value(groupStyle, {seriesIndex, pointIndex, point, series, props});
 
-        const transform = 'translate3d(' + x + 'px,' + y + 'px,0px)';
-        const style = _.defaults({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform
-        }, groupStyle);
+        const transform = 'translate(' + x + ',' + y + ')';
 
         dotType = helpers.value([dotType], {seriesIndex, pointIndex, point, series, props});
         dotAttributes = helpers.value(dotAttributes, {seriesIndex, pointIndex, point, dotType, series, props});
@@ -267,7 +262,8 @@ const Dots = React.createClass({
         return <g
             key={pointIndex}
             className={className && (className + '-dot ' + className + '-dot-' + pointIndex)}
-            style={style}>
+            style={groupStyle}
+            transform={transform}>
             {dot}
         </g>;
     },

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -59,20 +59,9 @@ var Layer = React.createClass({
 
         let {x, y} = this.getCoords();
         let transform = [];
-        transform.push('translate3d(' + x + 'px,' + y + 'px' + ',0px)');
+        transform.push('translate(' + x + ',' + y + '' + ')');
         transform = transform.join(' ') +
             (style && style.transform ? (' ' + style.transform) : '');
-
-        let transformOrigin = '' + layerWidth / 2 + 'px ' + layerHeight / 2 + 'px';
-
-        let layerStyle = _.assign({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform,
-            transformOrigin,
-            WebkitTransformOrigin: transformOrigin,
-            MozTransformOrigin: transformOrigin
-        }, style);
 
         let children = helpers.proxyChildren(
             this.props.children,
@@ -86,7 +75,7 @@ var Layer = React.createClass({
         );
 
 
-        return <g className={className} style={layerStyle}>
+        return <g className={className} style={style} transform={transform}>
             {children}
         </g>;
 

--- a/src/Pies.js
+++ b/src/Pies.js
@@ -182,10 +182,18 @@ const Pies = React.createClass({
         pieStyle = helpers.value([point.style, series.style, pieStyle], {seriesIndex, pointIndex, point, series, props});
         pieAttributes = helpers.value(pieAttributes, {seriesIndex, pointIndex, point, series, props});
 
+        // Used for setting `transform` (positioning) on the <path>
+        const {position, layerWidth, layerHeight} = props;
+        const innerRadius = this.getInnerRadius(props);
+        const outerRadius = this.getOuterRadius(props);
+        const coords = helpers.getCoords(position || '', layerWidth, layerHeight, outerRadius * 2, outerRadius * 2);
+        const transform = 'translate(' + (coords.x + outerRadius) + ',' + (coords.y + outerRadius) + ')';
+
         const pathProps = _.assign({
             style: pieStyle,
             fill: fillColor,
-            fillOpacity: point.opacity
+            fillOpacity: point.opacity,
+            transform: transform,
         }, pieAttributes);
 
         let pathList = [];
@@ -264,18 +272,9 @@ const Pies = React.createClass({
         const _startAngle = circularScale(0);
         this.color = helpers.colorFunc(colors);
 
-        const coords = helpers.getCoords(position || '', layerWidth, layerHeight, outerRadius * 2, outerRadius * 2);
-
-        const transform = 'translate3d(' + (coords.x + outerRadius) + 'px,' + (coords.y + outerRadius) + 'px,0px)';
-        const chartStyle = _.defaults({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform
-        }, style);
-
         const halfPadAngle = props.padAngle / 2 || 0;
 
-        return <g className={className} style={chartStyle} opacity={opacity}>
+        return <g className={className} style={style} opacity={opacity}>
             {_.map(series, (series, index) => {
 
                 let {seriesVisible, seriesAttributes, seriesStyle} = props;

--- a/src/RadialLines.js
+++ b/src/RadialLines.js
@@ -123,18 +123,14 @@ const RadialLines = React.createClass({
 
         let coords = helpers.getCoords(position || '', layerWidth, layerHeight, outerRadius * 2, outerRadius * 2);
 
-        let transform = 'translate3d(' + (coords.x + outerRadius) + 'px,' + (coords.y + outerRadius) + 'px,0px)';
-        let chartStyle = _.defaults({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform
-        }, style);
+        let transform = 'translate(' + (coords.x + outerRadius) + ',' + (coords.y + outerRadius) + ')';
 
         let color = helpers.colorFunc(colors);
 
         return <g
-            className={className} style={chartStyle}
-            opacity={opacity}>
+            className={className} style={style}
+            opacity={opacity}
+            transform={transform}>
 
             {_.map(series, (series, index) => {
 

--- a/src/Ticks.js
+++ b/src/Ticks.js
@@ -171,10 +171,13 @@ const Ticks = React.createClass({
             label = helpers.value([tick.label, label, tick[axis]], {index, ticksLength, tick, props});
             labelFormat = helpers.value(labelFormat, label) || label;
 
+            const transform = labelAttributes.transform ? labelAttributes.transform : '';
+
             if (_.isString(label) || _.isNumber(label)) {
                 label = <text
                     style={labelStyle}
                     className={className && (className + '-label ' + className + '-label-' + index)}
+                    transform={transform}
                     {...labelAttributes}>
                     {labelFormat}
                 </text>;

--- a/src/Ticks.js
+++ b/src/Ticks.js
@@ -136,25 +136,21 @@ const Ticks = React.createClass({
             return;
         }
 
-        tickAttributes = helpers.value(tickAttributes, {index, ticksLength, tick, props});
-        tickStyle = helpers.value(tickStyle, {index, ticksLength, tick, props});
-
         const pX = axis === 'x' ? x(tick.x) : helpers.normalizeNumber(position, layerWidth);
         const pY = axis === 'y' ? y(tick.y) : helpers.normalizeNumber(position, layerHeight);
 
         const transform = (scaleX.swap || scaleY.swap) ?
-            ('translate3d(' + pY + 'px,' + pX + 'px,0px)') :
-            ('translate3d(' + pX + 'px,' + pY + 'px,0px)');
+            ('translate(' + pY + ',' + pX + ')') :
+            ('translate(' + pX + ',' + pY + ')');
+        let {labelAttributes} = props;
 
-        const style = _.defaults({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform
-        }, tickStyle);
+        tickAttributes = helpers.value(tickAttributes, {index, ticksLength, tick, props});
+        tickStyle = helpers.value(tickStyle, {index, ticksLength, tick, props});
 
         return <g
-            key={index} style={style}
+            key={index} style={tickStyle}
             className={className && (className + '-tick ' + className + '-tick-' + index)}
+            transform={transform}
             {...tickAttributes}>
             {this.renderLabel(ticksLength, tick, index)}
             {this.renderLine(ticksLength, tick, index)}

--- a/src/Title.js
+++ b/src/Title.js
@@ -48,9 +48,9 @@ const Title = React.createClass({
 
         const {x, y} = helpers.getCoords(position, layerWidth, layerHeight, width, height) || {};
 
-        currentStyle.transform = 'translate(' + x + 'px,' + y + 'px)';
+        const transform = 'translate(' + x + ',' + y + ')';
 
-        return <g className={className} style={currentStyle}>
+        return <g className={className} style={currentStyle} transform={transform}>
             {_.isString(children) ?
                 <text>{children}</text> :
                 (_.isFunction(children) ? children(props) : children)}


### PR DESCRIPTION
Hi there! This isn't really a "full, proper PR" (it has a couple issues and I was having trouble running the style check), but it's enough to at least hopefully get things started.

These changes will make `rumble-js-charts` compatible with Internet Explorer 11 (for the most part).

The root of almost all of the issues were this one thing: using `transform/translate3d` within a `style` attribute rather than directly on the elements themselves. Here's the problem as it would present itself:

```diff
// BAD
- <g style="transform: translate3d(5px, 5px, 0px)" ... />

// GOOD
+ <g transform="translate(5, 5)" ... />
// important: note the lack of units!
```

**Fixing this wherever I could find it fixed almost every IE11 issue I was having.**

Unfortunately, the second issue I found seems to be a bit more of a doozy. I believe (i.e. am uncertain, please verify) that IE11 does NOT do sub-pixel translations. This means that the post-decimal remainder gets continually "lost" (creating a sort of "offset position debt") that will cause labels to be slightly offset from where they should be. Here's a screenshot of the issue as it presents itself:

![image](https://cloud.githubusercontent.com/assets/595711/15303692/e477b668-1b6d-11e6-9050-6f9ceb4aa95a.png)

![image](https://cloud.githubusercontent.com/assets/595711/15303703/f427da34-1b6d-11e6-89ca-1f27157103d2.png)

**Again, please verify that this is actually the isssue.. it might actually be a couple issues, as you'll notice the title "People" on the yellow bar chart is very close to the tick labels.**

I'm bummed that I couldn't fix this "completely", but hopefully it's enough that someone else might be able to spot my shortcomings.

NOTE: the aforementioned issue with style-checking seems to be that my linting ruleset is different from the project's version, as i got many code-style errors from a freshly cloned version of the repo. Let me know if you'd like further information.